### PR TITLE
[squid:S1149] Synchronized classes Vector, Hashtable, Stack and StringBuffer should not be used

### DIFF
--- a/modules/jetm-console/src/main/java/etm/contrib/console/util/ConsoleRenderer.java
+++ b/modules/jetm-console/src/main/java/etm/contrib/console/util/ConsoleRenderer.java
@@ -473,7 +473,7 @@ public abstract class ConsoleRenderer implements MeasurementRenderer {
   }
 
   protected String encodeHtml(String text) {
-    StringBuffer result = new StringBuffer();
+    StringBuilder result = new StringBuilder();
     char[] chars = text.toCharArray();
     for (int i = 0; i < chars.length; i++) {
       char c = chars[i];

--- a/modules/jetm-console/src/main/java/etm/contrib/console/util/ConsoleUtil.java
+++ b/modules/jetm-console/src/main/java/etm/contrib/console/util/ConsoleUtil.java
@@ -56,7 +56,7 @@ public class ConsoleUtil {
   }
 
   public static String appendParameters(String url, Map parameters, boolean removeDetails) {
-    StringBuffer result = new StringBuffer(url);
+    StringBuilder result = new StringBuilder(url);
 
     try {
       if (parameters != null && parameters.size() > 0) {

--- a/modules/jetm-core/src/main/java/etm/core/jmx/EtmMonitorMBean.java
+++ b/modules/jetm-core/src/main/java/etm/core/jmx/EtmMonitorMBean.java
@@ -92,7 +92,7 @@ public class EtmMonitorMBean extends JmxSupport implements DynamicMBean {
     EtmMonitorMetaData etmMonitorMetaData = etmMonitor.getMetaData();
 
     AggregatorMetaData metaData = etmMonitorMetaData.getAggregatorMetaData();
-    StringBuffer chain = new StringBuffer(metaData.getImplementationClass().getName());
+    StringBuilder chain = new StringBuilder(metaData.getImplementationClass().getName());
     metaData = metaData.getNestedMetaData();
 
     while (metaData != null) {

--- a/modules/jetm-core/src/main/java/etm/core/metadata/AggregatorMetaData.java
+++ b/modules/jetm-core/src/main/java/etm/core/metadata/AggregatorMetaData.java
@@ -95,7 +95,7 @@ public class AggregatorMetaData implements Serializable {
   }
 
   public String toString() {
-    StringBuffer buffer = new StringBuffer("implementationClass=");
+    StringBuilder buffer = new StringBuilder("implementationClass=");
     buffer.append(implementationClass.getName());
     buffer.append(", description='");
     buffer.append(description);

--- a/modules/jetm-core/src/main/java/etm/core/metadata/EtmMonitorMetaData.java
+++ b/modules/jetm-core/src/main/java/etm/core/metadata/EtmMonitorMetaData.java
@@ -161,7 +161,7 @@ public class EtmMonitorMetaData implements Serializable {
   }
 
   public String toString() {
-    StringBuffer buffer = new StringBuffer("Monitor ");
+    StringBuilder buffer = new StringBuilder("Monitor ");
     buffer.append(monitorClazz);
     buffer.append(" (");
     buffer.append(monitorDescription);


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1149 - “Synchronized classes Vector, Hashtable, Stack and StringBuffer should not be used ”. 
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1149
Please let me know if you have any questions.
Ayman Abdelghany.