### PR TITLE
[squid:S1118] Utility classes should not have public constructors

### DIFF
--- a/modules/jetm-aop/src/main/java/etm/contrib/aop/joinpoint/JoinPointFactory.java
+++ b/modules/jetm-aop/src/main/java/etm/contrib/aop/joinpoint/JoinPointFactory.java
@@ -47,6 +47,9 @@ import org.jboss.aop.joinpoint.Invocation;
  */
 public class JoinPointFactory {
 
+  private JoinPointFactory() {
+  }
+
   public static EtmJoinPoint create(MethodInvocation aMethodInvocation) {
     return new AopAllianceJoinPoint(aMethodInvocation);
   }

--- a/modules/jetm-console/src/main/java/etm/contrib/console/util/ConsoleUtil.java
+++ b/modules/jetm-console/src/main/java/etm/contrib/console/util/ConsoleUtil.java
@@ -51,6 +51,9 @@ import java.util.Map;
 
 public class ConsoleUtil {
 
+  private ConsoleUtil() {
+  }
+
   public static String appendParameters(String url, Map parameters) {
     return appendParameters(url, parameters, false);
   }

--- a/modules/jetm-core/src/main/java/etm/core/configuration/BasicEtmConfigurator.java
+++ b/modules/jetm-core/src/main/java/etm/core/configuration/BasicEtmConfigurator.java
@@ -58,6 +58,9 @@ import etm.core.timer.ExecutionTimer;
  */
 public class BasicEtmConfigurator {
 
+  private BasicEtmConfigurator() {
+  }
+
   /**
    *
    * Configures {@link EtmManager} to use a {@link FlatMonitor}

--- a/modules/jetm-core/src/main/java/etm/core/configuration/EtmMonitorFactory.java
+++ b/modules/jetm-core/src/main/java/etm/core/configuration/EtmMonitorFactory.java
@@ -65,6 +65,9 @@ public class EtmMonitorFactory {
     "etm.core.timer.DefaultTimer"
   };
 
+  private EtmMonitorFactory() {
+  }
+
 
   public static EtmMonitor createEtmMonitor(EtmMonitorConfig monitorConfig) throws Exception {
     Object obj;

--- a/modules/jetm-core/src/main/java/etm/core/util/PropertySupport.java
+++ b/modules/jetm-core/src/main/java/etm/core/util/PropertySupport.java
@@ -48,6 +48,9 @@ import java.util.Map;
  */
 public class PropertySupport {
 
+  private PropertySupport() {
+  }
+
   public static Object create(String aClassName, Map properties) {
     try {
       return create(Class.forName(aClassName), properties);

--- a/modules/jetm-legacy/src/main/java/etm/contrib/integration/jca/EtmMonitorRepository.java
+++ b/modules/jetm-legacy/src/main/java/etm/contrib/integration/jca/EtmMonitorRepository.java
@@ -49,6 +49,9 @@ class EtmMonitorRepository {
 
   private static Map managedMonitors = new HashMap();
 
+  private EtmMonitorRepository() {
+  }
+
   public static void register(String reference, EtmMonitor aMonitor) {
     if (!managedMonitors.containsKey(reference)) {
       managedMonitors.put(reference, aMonitor);


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1118 - “Utility classes should not have public constructors ”. 
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1118
Please let me know if you have any questions.
Ayman Abdelghany.