### PR TITLE
[squid:S1155] Using Collection.isEmpty() to test for emptiness

### DIFF
--- a/modules/jetm-aop/src/test/java/etm/contrib/aop/AopTestBase.java
+++ b/modules/jetm-aop/src/test/java/etm/contrib/aop/AopTestBase.java
@@ -81,7 +81,7 @@ public abstract class AopTestBase extends TestCase {
 
     etmMonitor.render(new MeasurementRenderer() {
       public void render(Map points) {
-        assertTrue("No measurement result found.", points.size() > 0);
+        assertTrue("No measurement result found.", !points.isEmpty());
         Aggregate topLevelBar = ((Aggregate) points.get("BarService::doBar"));
         assertTrue(topLevelBar.getTotal() > 0);
         assertTrue(topLevelBar.getMin() > 0);

--- a/modules/jetm-aop/src/test/java/etm/contrib/aop/aopalliance/MethodCallInterceptorTest.java
+++ b/modules/jetm-aop/src/test/java/etm/contrib/aop/aopalliance/MethodCallInterceptorTest.java
@@ -73,7 +73,7 @@ public class MethodCallInterceptorTest extends TestCase {
 
       monitor.render(new MeasurementRenderer() {
         public void render(Map points) {
-          assertTrue(points.size() > 0);
+          assertTrue(!points.isEmpty());
           assertNotNull(points.get("FooService::doFoo"));
           assertNotNull(points.get("FooService::doFoo [Exception]"));
         }

--- a/modules/jetm-aop/src/test/java/etm/contrib/aop/aspectwerkz/FunctionalAspectWerkzTest.java
+++ b/modules/jetm-aop/src/test/java/etm/contrib/aop/aspectwerkz/FunctionalAspectWerkzTest.java
@@ -79,7 +79,7 @@ public class FunctionalAspectWerkzTest extends TestCase {
 
       monitor.render(new MeasurementRenderer() {
         public void render(Map points) {
-          assertTrue(points.size() > 0);
+          assertTrue(!points.isEmpty());
           assertNotNull(points.get("FooService::doFoo"));
           assertNotNull(points.get("FooService::doFoo [Exception]"));
         }

--- a/modules/jetm-core/src/test/java/etm/core/configuration/Xml10EtmConfiguratorTest.java
+++ b/modules/jetm-core/src/test/java/etm/core/configuration/Xml10EtmConfiguratorTest.java
@@ -158,7 +158,7 @@ public class Xml10EtmConfiguratorTest extends TestCase {
     EtmMonitor etmMonitor = EtmManager.getEtmMonitor();
     List plugins = ((TestMonitor) etmMonitor).getPlugins();
 
-    assertTrue(plugins.size() > 0);
+    assertTrue(!plugins.isEmpty());
 
     EtmPlugin plugin = (EtmPlugin) plugins.get(0);
 

--- a/modules/jetm-core/src/test/java/etm/core/configuration/Xml12EtmConfiguratorTest.java
+++ b/modules/jetm-core/src/test/java/etm/core/configuration/Xml12EtmConfiguratorTest.java
@@ -142,7 +142,7 @@ public class Xml12EtmConfiguratorTest extends TestCase {
     EtmMonitor etmMonitor = EtmManager.getEtmMonitor();
     List plugins = ((TestMonitor) etmMonitor).getPlugins();
 
-    assertTrue(plugins.size() > 0);
+    assertTrue(!plugins.isEmpty());
 
     EtmPlugin plugin = (EtmPlugin) plugins.get(0);
 

--- a/modules/jetm-core/src/test/java/etm/core/monitor/CommonMonitorTests.java
+++ b/modules/jetm-core/src/test/java/etm/core/monitor/CommonMonitorTests.java
@@ -238,7 +238,7 @@ public abstract class CommonMonitorTests extends TestCase {
     monitor.render(new MeasurementRenderer() {
       public void render(Map points) {
         assertNotNull(points);
-        assertTrue(points.size() == 0);
+        assertTrue(points.isEmpty());
       }
     });
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1155 - “Collection.isEmpty() should be used to test for emptiness”. 
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1155
Please let me know if you have any questions.
Ayman Abdelghany.